### PR TITLE
Overcome overloading problems using Generics

### DIFF
--- a/src/test/scala/com/github/mrpowers/spark/daria/sql/SparkSessionExtSpec.scala
+++ b/src/test/scala/com/github/mrpowers/spark/daria/sql/SparkSessionExtSpec.scala
@@ -1,21 +1,22 @@
 package com.github.mrpowers.spark.daria.sql
 
-import SparkSessionExt._
+import com.github.mrpowers.spark.daria.sql.SparkSessionExt._
 import com.holdenkarau.spark.testing.DataFrameSuiteBase
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 import org.scalatest.FunSpec
 
 class SparkSessionExtSpec extends FunSpec with DataFrameSuiteBase {
 
   describe("#createDF") {
 
-    it("creates a DataFrame") {
+    it("creates a DataFrame with a list of Row and List of StructField") {
 
       val actualDF = spark.createDF(
         List(
           Row(1, 2)
-        ), List(
+        ),
+        List(
           StructField("num1", IntegerType, true),
           StructField("num2", IntegerType, true)
         )
@@ -39,41 +40,75 @@ class SparkSessionExtSpec extends FunSpec with DataFrameSuiteBase {
 
     }
 
-    it("creates a DataFrame with an array of tuples instead of StructFields") {
+    it(
+      "creates a DataFrame with an List of Row and Tuples instead of StructFields"
+    ) {
 
-      val actualDF = spark.createDF(
-        List(
-          Row(1, 2)
-        ), List(
-          ("num1", IntegerType, true),
-          ("num2", IntegerType, true)
+        val actualDF = spark.createDF(
+          List(
+            Row(1, 2)
+          ),
+          List(
+            ("num1", IntegerType, true),
+            ("num2", IntegerType, true)
+          )
         )
-      )
 
-      val expectedData = List(
-        Row(1, 2)
-      )
+        val expectedData = List(
+          Row(1, 2)
+        )
 
-      val expectedSchema = List(
-        StructField("num1", IntegerType, true),
-        StructField("num2", IntegerType, true)
-      )
+        val expectedSchema = List(
+          StructField("num1", IntegerType, true),
+          StructField("num2", IntegerType, true)
+        )
 
-      val expectedDF = spark.createDataFrame(
-        spark.sparkContext.parallelize(expectedData),
-        StructType(expectedSchema)
-      )
+        val expectedDF = spark.createDataFrame(
+          spark.sparkContext.parallelize(expectedData),
+          StructType(expectedSchema)
+        )
 
-      assertDataFrameEquals(actualDF, expectedDF)
+        assertDataFrameEquals(actualDF, expectedDF)
 
-    }
+      }
 
-    it("creates a DataFrame with lists of tuples") {
+    it("creates a DataFrame with lists of tuples for data and StructFields") {
 
       val actualDF = spark.createDF(
         List(
           (1, 2)
-        ), List(
+        ),
+        List(
+          StructField("num1", IntegerType, true),
+          StructField("num2", IntegerType, true)
+        )
+      )
+
+      val expectedData = List(
+        Row(1, 2)
+      )
+
+      val expectedSchema = List(
+        StructField("num1", IntegerType, true),
+        StructField("num2", IntegerType, true)
+      )
+
+      val expectedDF = spark.createDataFrame(
+        spark.sparkContext.parallelize(expectedData),
+        StructType(expectedSchema)
+      )
+
+      assertDataFrameEquals(actualDF, expectedDF)
+
+    }
+
+    it("creates a Dataframe with a list of tuples for both values and StructFields") {
+
+      val actualDF = spark.createDF(
+        List(
+          (1, 2)
+        ),
+        List(
           ("num1", IntegerType, true),
           ("num2", IntegerType, true)
         )
@@ -97,19 +132,35 @@ class SparkSessionExtSpec extends FunSpec with DataFrameSuiteBase {
 
     }
 
-    it("requires an implicit definition when only the column is present") {
+    it("creates a Dataframe with a list of primitives for data and tuples of struct fields") {
 
-      val namesDF = spark.createDF(
+      val actualDF = spark.createDF(
         List(
-          ("Alice"),
-          ("Bob")
-        ), List(
-          ("Name", StringType, true)
+          1,
+          2
+        ),
+        List(
+          ("num1", IntegerType, true)
         )
       )
 
-    }
+      val expectedData = List(
+        Row(1),
+        Row(2)
+      )
 
+      val expectedSchema = List(
+        StructField("num1", IntegerType, true)
+      )
+
+      val expectedDF = spark.createDataFrame(
+        spark.sparkContext.parallelize(expectedData),
+        StructType(expectedSchema)
+      )
+
+      assertDataFrameEquals(actualDF, expectedDF)
+
+    }
   }
 
 }


### PR DESCRIPTION
Overloading and implicit have been removed for a cleaner approach based on Generics.

Overloading has been abstracted to `def asRows[U]` and Row construction delegated to pattern matching.