### PR TITLE
Add Json extract as a transform

### DIFF
--- a/src/main/scala/com/github/mrpowers/spark/daria/sql/DataFrameExt.scala
+++ b/src/main/scala/com/github/mrpowers/spark/daria/sql/DataFrameExt.scala
@@ -71,9 +71,25 @@ object DataFrameExt {
      *
      * sourceDF.composeTransforms(transforms)
      */
-    def composeTransforms(
-      transforms: List[(DataFrame => DataFrame)]
-    ): DataFrame = {
+    def composeTransforms(transforms: List[(DataFrame => DataFrame)]): DataFrame = {
+      composeTransforms(transforms: _*)
+    }
+
+    /**
+      * Executes a list of custom DataFrame transformations
+      * Uses function composition to run a list of DataFrame transformations.
+      *
+      * def withGreeting()(df: DataFrame): DataFrame = {
+      *   df.withColumn("greeting", lit("hello world"))
+      * }
+      *
+      * def withCat(name: String)(df: DataFrame): DataFrame = {
+      *   df.withColumn("cats", lit(name + " meow"))
+      * }
+      *
+      * sourceDF.composeTransforms(withGreeting(), withCat("sandy"))
+      */
+    def composeTransforms(transforms: (DataFrame => DataFrame)*): DataFrame = {
       transforms.foldLeft(df) { (memoDF, t) =>
         memoDF.transform(t)
       }

--- a/src/main/scala/com/github/mrpowers/spark/daria/sql/transformations.scala
+++ b/src/main/scala/com/github/mrpowers/spark/daria/sql/transformations.scala
@@ -216,4 +216,40 @@ object transformations {
     )
   }
 
+  /**
+    * Extracts an object from a JSON field with a specified schema
+    *
+    * {{{
+    * val sourceDF = spark.createDF(
+    *   List(
+    *     (10, """{"name": "Bart cool", "age": 25}"""),
+    *     (20, """{"name": "Lisa frost", "age": 27}""")
+    *   ), List(
+    *     ("id", IntegerType, true),
+    *     ("person", StringType, true)
+    *   )
+    * )
+    *
+    * val personSchema = StructType(List(
+    *   StructField("name", StringType),
+    *   StructField("age", IntegerType)
+    * ))
+    *
+    * val actualDF = sourceDF.transform(
+    *   transformations.extractFromJson("person", "personData", personSchema)
+    * )
+    *
+    * sourceDF.show()
+    * +---+---------------------------------+----------------+
+    * |id |person                           |personData      |
+    * +---+---------------------------------+----------------+
+    * |10 |{"name": "Bart cool", "age": 25} |[Bart cool, 25] |
+    * |20 |{"name": "Lisa frost", "age": 27}|[Lisa frost, 27]|
+    * +---+---------------------------------+----------------+
+    * }}}
+    */
+  def extractFromJson(colName: String, outputColName: String, jsonSchema: StructType)(df: DataFrame): DataFrame = {
+    df.withColumn(outputColName, from_json(col(colName), jsonSchema))
+  }
+
 }

--- a/src/test/scala/com/github/mrpowers/spark/daria/sql/DataFrameExtTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/daria/sql/DataFrameExtTest.scala
@@ -37,16 +37,27 @@ object DataFrameExtTest
 
     'composeTransforms - {
 
-      "runs a list of transforms" - {
-
-        val sourceDF = spark.createDF(
-          List(
-            ("jets"),
-            ("nacional")
-          ), List(
-            ("team", StringType, true)
-          )
+      val sourceDF = spark.createDF(
+        List(
+          ("jets"),
+          ("nacional")
+        ), List(
+          ("team", StringType, true)
         )
+      )
+
+      val expectedDF = spark.createDF(
+        List(
+          ("jets", "hello world", "sandy meow"),
+          ("nacional", "hello world", "sandy meow")
+        ), List(
+          ("team", StringType, true),
+          ("greeting", StringType, false),
+          ("cats", StringType, false)
+        )
+      )
+
+      "runs a list of transforms" - {
 
         val transforms = List(
           ExampleTransforms.withGreeting()(_),
@@ -55,15 +66,15 @@ object DataFrameExtTest
 
         val actualDF = sourceDF.composeTransforms(transforms)
 
-        val expectedDF = spark.createDF(
-          List(
-            ("jets", "hello world", "sandy meow"),
-            ("nacional", "hello world", "sandy meow")
-          ), List(
-            ("team", StringType, true),
-            ("greeting", StringType, false),
-            ("cats", StringType, false)
-          )
+        assertSmallDataFrameEquality(actualDF, expectedDF)
+
+      }
+
+      "runs a sequence of transforms" - {
+
+        val actualDF = sourceDF.composeTransforms(
+          ExampleTransforms.withGreeting(),
+          ExampleTransforms.withCat("sandy")
         )
 
         assertSmallDataFrameEquality(actualDF, expectedDF)


### PR DESCRIPTION
At Schibsted we have more or less the same approach that spark-daria has, so our idea was to start adding some transformations that we are already using. Some of them are already provided by daria.

In this PR we are:
- Extending the `composeTransforms` to work with a vararg.
- Providing the JSON extract method as a transform.