### PR TITLE
WIP Add higher order functions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ crossScalaVersions := Seq("2.11.12", "2.12.7")
 scalaVersion := "2.11.12"
 sparkVersion := "2.4.2"
 
+libraryDependencies += "org.apache.spark" %% "spark-catalyst" % "2.4.2" % "provided"
 libraryDependencies += "org.apache.spark" %% "spark-sql" % "2.4.2" % "provided"
 libraryDependencies += "org.apache.spark" %% "spark-mllib" % "2.4.2" % "provided"
 

--- a/src/main/scala/org/apache/spark/sql/catalyst/expressions/daria/higherOrderFunctions.scala
+++ b/src/main/scala/org/apache/spark/sql/catalyst/expressions/daria/higherOrderFunctions.scala
@@ -1,0 +1,829 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions.daria
+
+import java.util.concurrent.atomic.AtomicReference
+
+import scala.collection.mutable
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.analysis.{TypeCheckResult, TypeCoercion, UnresolvedAttribute, UnresolvedException}
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.codegen._
+import org.apache.spark.sql.catalyst.util._
+import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.array.ByteArrayMethods
+
+/**
+ * Helper methods for constructing higher order functions.
+ */
+object HigherOrderUtils {
+
+  def createLambda(dt: DataType, nullable: Boolean, f: Expression => Expression): Expression = {
+    val lv = NamedLambdaVariable(
+      "arg",
+      dt,
+      nullable
+    )
+    val function = f(lv)
+    LambdaFunction(
+      function,
+      Seq(lv)
+    )
+  }
+
+  def createLambda(dt1: DataType, nullable1: Boolean, dt2: DataType, nullable2: Boolean, f: (Expression, Expression) => Expression): Expression = {
+    val lv1 = NamedLambdaVariable(
+      "arg1",
+      dt1,
+      nullable1
+    )
+    val lv2 = NamedLambdaVariable(
+      "arg2",
+      dt2,
+      nullable2
+    )
+    val function = f(
+      lv1,
+      lv2
+    )
+    LambdaFunction(
+      function,
+      Seq(
+        lv1,
+        lv2
+      )
+    )
+  }
+
+  def createLambda(dt1: DataType, nullable1: Boolean, dt2: DataType, nullable2: Boolean, dt3: DataType, nullable3: Boolean, f: (Expression, Expression, Expression) => Expression): Expression = {
+    val lv1 = NamedLambdaVariable(
+      "arg1",
+      dt1,
+      nullable1
+    )
+    val lv2 = NamedLambdaVariable(
+      "arg2",
+      dt2,
+      nullable2
+    )
+    val lv3 = NamedLambdaVariable(
+      "arg3",
+      dt3,
+      nullable3
+    )
+    val function = f(
+      lv1,
+      lv2,
+      lv3
+    )
+    LambdaFunction(
+      function,
+      Seq(
+        lv1,
+        lv2,
+        lv3
+      )
+    )
+  }
+
+  def validateBinding(e: Expression, argInfo: Seq[(DataType, Boolean)]): LambdaFunction = e match {
+    case f: LambdaFunction =>
+      assert(f.arguments.size == argInfo.size)
+      f.arguments.zip(argInfo).foreach {
+        case (arg, (dataType, nullable)) =>
+          assert(arg.dataType == dataType)
+          assert(arg.nullable == nullable)
+      }
+      f
+  }
+
+  // Array-based helpers
+  def filter(expr: Expression, f: Expression => Expression): Expression = {
+    val ArrayType(et, cn) = expr.dataType
+    ArrayFilter(
+      expr,
+      createLambda(
+        et,
+        cn,
+        f
+      )
+    ).bind(validateBinding)
+  }
+
+  def exists(expr: Expression, f: Expression => Expression): Expression = {
+    val ArrayType(et, cn) = expr.dataType
+    ArrayExists(
+      expr,
+      createLambda(
+        et,
+        cn,
+        f
+      )
+    ).bind(validateBinding)
+  }
+
+  def transform(expr: Expression, f: Expression => Expression): Expression = {
+    val ArrayType(et, cn) = expr.dataType
+    ArrayTransform(
+      expr,
+      createLambda(
+        et,
+        cn,
+        f
+      )
+    ).bind(validateBinding)
+  }
+
+  def transform(expr: Expression, f: (Expression, Expression) => Expression): Expression = {
+    val ArrayType(et, cn) = expr.dataType
+    ArrayTransform(
+      expr,
+      createLambda(
+        et,
+        cn,
+        IntegerType,
+        false,
+        f
+      )
+    ).bind(validateBinding)
+  }
+
+  def aggregate(expr: Expression, zero: Expression, merge: (Expression, Expression) => Expression, finish: Expression => Expression): Expression = {
+    val ArrayType(et, cn) = expr.dataType
+    val zeroType          = zero.dataType
+    ArrayAggregate(
+      expr,
+      zero,
+      createLambda(
+        zeroType,
+        true,
+        et,
+        cn,
+        merge
+      ),
+      createLambda(
+        zeroType,
+        true,
+        finish
+      )
+    ).bind(validateBinding)
+  }
+
+  def aggregate(expr: Expression, zero: Expression, merge: (Expression, Expression) => Expression): Expression = {
+    aggregate(
+      expr,
+      zero,
+      merge,
+      identity
+    )
+  }
+
+  def zip_with(left: Expression, right: Expression, f: (Expression, Expression) => Expression): Expression = {
+    val ArrayType(leftT, _)  = left.dataType
+    val ArrayType(rightT, _) = right.dataType
+    ZipWith(
+      left,
+      right,
+      createLambda(
+        leftT,
+        true,
+        rightT,
+        true,
+        f
+      )
+    ).bind(validateBinding)
+  }
+}
+
+/**
+ * A placeholder of lambda variables to prevent unexpected resolution of [[LambdaFunction]].
+ */
+case class UnresolvedNamedLambdaVariable(nameParts: Seq[String]) extends LeafExpression with NamedExpression with Unevaluable {
+
+  override def name: String =
+    nameParts.map(n => if (n.contains(".")) s"`$n`" else n).mkString(".")
+
+  override def exprId: ExprId =
+    throw new UnresolvedException(
+      this,
+      "exprId"
+    )
+  override def dataType: DataType =
+    throw new UnresolvedException(
+      this,
+      "dataType"
+    )
+  override def nullable: Boolean =
+    throw new UnresolvedException(
+      this,
+      "nullable"
+    )
+  override def qualifier: Seq[String] =
+    throw new UnresolvedException(
+      this,
+      "qualifier"
+    )
+  override def toAttribute: Attribute =
+    throw new UnresolvedException(
+      this,
+      "toAttribute"
+    )
+  override def newInstance(): NamedExpression =
+    throw new UnresolvedException(
+      this,
+      "newInstance"
+    )
+  override lazy val resolved = false
+
+  override def toString: String = s"lambda '$name"
+
+  override def sql: String = name
+}
+
+/**
+ * A named lambda variable.
+ */
+case class NamedLambdaVariable(name: String, dataType: DataType, nullable: Boolean, exprId: ExprId = NamedExpression.newExprId, value: AtomicReference[Any] = new AtomicReference()) extends LeafExpression with NamedExpression with CodegenFallback {
+
+  override def qualifier: Seq[String] = Seq.empty
+
+  override def newInstance(): NamedExpression =
+    copy(
+      exprId = NamedExpression.newExprId,
+      value = new AtomicReference()
+    )
+
+  override def toAttribute: Attribute = {
+    AttributeReference(
+      name,
+      dataType,
+      nullable,
+      Metadata.empty
+    )(
+      exprId,
+      Seq.empty
+    )
+  }
+
+  override def eval(input: InternalRow): Any = value.get
+
+  override def toString: String = s"lambda $name#${exprId.id}$typeSuffix"
+
+  def simpleString(maxFields: Int): String = {
+    s"lambda $name#${exprId.id}: ${dataType.simpleString(maxFields)}"
+  }
+}
+
+/**
+ * A lambda function and its arguments. A lambda function can be hidden when a user wants to
+ * process an completely independent expression in a [[HigherOrderFunction]], the lambda function
+ * and its variables are then only used for internal bookkeeping within the higher order function.
+ */
+case class LambdaFunction(function: Expression, arguments: Seq[NamedExpression], hidden: Boolean = false) extends Expression with CodegenFallback {
+
+  override def children: Seq[Expression] = function +: arguments
+  override def dataType: DataType        = function.dataType
+  override def nullable: Boolean         = function.nullable
+
+  lazy val bound: Boolean = arguments.forall(_.resolved)
+
+  override def eval(input: InternalRow): Any = function.eval(input)
+}
+
+object LambdaFunction {
+
+  val identity: LambdaFunction = {
+    val id = UnresolvedNamedLambdaVariable(Seq("id"))
+    LambdaFunction(
+      id,
+      Seq(id)
+    )
+  }
+}
+
+/**
+ * A higher order function takes one or more (lambda) functions and applies these to some objects.
+ * The function produces a number of variables which can be consumed by some lambda function.
+ */
+trait HigherOrderFunction extends Expression with ExpectsInputTypes {
+
+  override def nullable: Boolean = arguments.exists(_.nullable)
+
+  override def children: Seq[Expression] = arguments ++ functions
+
+  /**
+   * Arguments of the higher ordered function.
+   */
+  def arguments: Seq[Expression]
+
+  def argumentTypes: Seq[AbstractDataType]
+
+  /**
+   * All arguments have been resolved. This means that the types and nullabilty of (most of) the
+   * lambda function arguments is known, and that we can start binding the lambda functions.
+   */
+  lazy val argumentsResolved: Boolean = arguments.forall(_.resolved)
+
+  /**
+   * Checks the argument data types, returns `TypeCheckResult.success` if it's valid,
+   * or returns a `TypeCheckResult` with an error message if invalid.
+   * Note: it's not valid to call this method until `argumentsResolved == true`.
+   */
+  def checkArgumentDataTypes(): TypeCheckResult = {
+    ExpectsInputTypes.checkInputDataTypes(
+      arguments,
+      argumentTypes
+    )
+  }
+
+  /**
+   * Functions applied by the higher order function.
+   */
+  def functions: Seq[Expression]
+
+  def functionTypes: Seq[AbstractDataType]
+
+  override def inputTypes: Seq[AbstractDataType] = argumentTypes ++ functionTypes
+
+  /**
+   * All inputs must be resolved and all functions must be resolved lambda functions.
+   */
+  override lazy val resolved: Boolean = argumentsResolved && functions.forall {
+    case l: LambdaFunction => l.resolved
+    case _                 => false
+  }
+
+  /**
+   * Bind the lambda functions to the [[HigherOrderFunction]] using the given bind function. The
+   * bind function takes the potential lambda and it's (partial) arguments and converts this into
+   * a bound lambda function.
+   */
+  def bind(f: (Expression, Seq[(DataType, Boolean)]) => LambdaFunction): HigherOrderFunction
+
+  // Make sure the lambda variables refer the same instances as of arguments for case that the
+  // variables in instantiated separately during serialization or for some reason.
+  @transient lazy val functionsForEval: Seq[Expression] = functions.map {
+    case LambdaFunction(function, arguments, hidden) =>
+      val argumentMap = arguments.map { arg =>
+        arg.exprId -> arg
+      }.toMap
+      function.transformUp {
+        case variable: NamedLambdaVariable if argumentMap.contains(variable.exprId) =>
+          argumentMap(variable.exprId)
+      }
+  }
+}
+
+/**
+ * Trait for functions having as input one argument and one function.
+ */
+trait SimpleHigherOrderFunction extends HigherOrderFunction {
+
+  def argument: Expression
+
+  override def arguments: Seq[Expression] = argument :: Nil
+
+  def argumentType: AbstractDataType
+
+  override def argumentTypes(): Seq[AbstractDataType] = argumentType :: Nil
+
+  def function: Expression
+
+  override def functions: Seq[Expression] = function :: Nil
+
+  def functionType: AbstractDataType = AnyDataType
+
+  override def functionTypes: Seq[AbstractDataType] = functionType :: Nil
+
+  def functionForEval: Expression = functionsForEval.head
+
+  /**
+   * Called by [[eval]]. If a subclass keeps the default nullability, it can override this method
+   * in order to save null-check code.
+   */
+  protected def nullSafeEval(inputRow: InternalRow, argumentValue: Any): Any =
+    sys.error(s"UnaryHigherOrderFunction must override either eval or nullSafeEval")
+
+  override def eval(inputRow: InternalRow): Any = {
+    val value = argument.eval(inputRow)
+    if (value == null) {
+      null
+    } else {
+      nullSafeEval(
+        inputRow,
+        value
+      )
+    }
+  }
+}
+
+trait ArrayBasedSimpleHigherOrderFunction extends SimpleHigherOrderFunction {
+  override def argumentType: AbstractDataType = ArrayType
+}
+
+/**
+ * Transform elements in an array using the transform function. This is similar to
+ * a `map` in functional programming.
+ */
+@ExpressionDescription(
+  usage = "_FUNC_(expr, func) - Transforms elements in an array using the function.",
+  examples = """
+    Examples:
+      > SELECT _FUNC_(array(1, 2, 3), x -> x + 1);
+       [2,3,4]
+      > SELECT _FUNC_(array(1, 2, 3), (x, i) -> x + i);
+       [1,3,5]
+  """,
+  since = "2.4.0"
+)
+case class ArrayTransform(argument: Expression, function: Expression) extends ArrayBasedSimpleHigherOrderFunction with CodegenFallback {
+
+  override def dataType: ArrayType =
+    ArrayType(
+      function.dataType,
+      function.nullable
+    )
+
+  override def bind(f: (Expression, Seq[(DataType, Boolean)]) => LambdaFunction): ArrayTransform = {
+    val ArrayType(elementType, containsNull) = argument.dataType
+    function match {
+      case LambdaFunction(_, arguments, _) if arguments.size == 2 =>
+        copy(
+          function = f(
+            function,
+            (elementType, containsNull) :: (IntegerType, false) :: Nil
+          )
+        )
+      case _ =>
+        copy(
+          function = f(
+            function,
+            (elementType, containsNull) :: Nil
+          )
+        )
+    }
+  }
+
+  @transient lazy val (elementVar, indexVar) = {
+    val LambdaFunction(_, (elementVar: NamedLambdaVariable) +: tail, _) = function
+    val indexVar = if (tail.nonEmpty) {
+      Some(tail.head.asInstanceOf[NamedLambdaVariable])
+    } else {
+      None
+    }
+    (elementVar, indexVar)
+  }
+
+  override def nullSafeEval(inputRow: InternalRow, argumentValue: Any): Any = {
+    val arr    = argumentValue.asInstanceOf[ArrayData]
+    val f      = functionForEval
+    val result = new GenericArrayData(new Array[Any](arr.numElements))
+    var i      = 0
+    while (i < arr.numElements) {
+      elementVar.value.set(
+        arr.get(
+          i,
+          elementVar.dataType
+        )
+      )
+      if (indexVar.isDefined) {
+        indexVar.get.value.set(i)
+      }
+      result.update(
+        i,
+        f.eval(inputRow)
+      )
+      i += 1
+    }
+    result
+  }
+
+  override def prettyName: String = "transform"
+}
+
+/**
+ * Filters the input array using the given lambda function.
+ */
+@ExpressionDescription(
+  usage = "_FUNC_(expr, func) - Filters the input array using the given predicate.",
+  examples = """
+    Examples:
+      > SELECT _FUNC_(array(1, 2, 3), x -> x % 2 == 1);
+       [1,3]
+  """,
+  since = "2.4.0"
+)
+case class ArrayFilter(argument: Expression, function: Expression) extends ArrayBasedSimpleHigherOrderFunction with CodegenFallback {
+
+  override def dataType: DataType = argument.dataType
+
+  override def functionType: AbstractDataType = BooleanType
+
+  override def bind(f: (Expression, Seq[(DataType, Boolean)]) => LambdaFunction): ArrayFilter = {
+    val ArrayType(elementType, containsNull) = argument.dataType
+    copy(
+      function = f(
+        function,
+        (elementType, containsNull) :: Nil
+      )
+    )
+  }
+
+  @transient lazy val LambdaFunction(_, Seq(elementVar: NamedLambdaVariable), _) = function
+
+  override def nullSafeEval(inputRow: InternalRow, argumentValue: Any): Any = {
+    val arr    = argumentValue.asInstanceOf[ArrayData]
+    val f      = functionForEval
+    val buffer = new mutable.ArrayBuffer[Any](arr.numElements)
+    var i      = 0
+    while (i < arr.numElements) {
+      elementVar.value.set(
+        arr.get(
+          i,
+          elementVar.dataType
+        )
+      )
+      if (f.eval(inputRow).asInstanceOf[Boolean]) {
+        buffer += elementVar.value.get
+      }
+      i += 1
+    }
+    new GenericArrayData(buffer)
+  }
+
+  override def prettyName: String = "filter"
+}
+
+/**
+ * Tests whether a predicate holds for one or more elements in the array.
+ */
+@ExpressionDescription(
+  usage = "_FUNC_(expr, pred) - Tests whether a predicate holds for one or more elements in the array.",
+  examples = """
+    Examples:
+      > SELECT _FUNC_(array(1, 2, 3), x -> x % 2 == 0);
+       true
+  """,
+  since = "2.4.0"
+)
+case class ArrayExists(argument: Expression, function: Expression) extends ArrayBasedSimpleHigherOrderFunction with CodegenFallback {
+
+  override def dataType: DataType = BooleanType
+
+  override def functionType: AbstractDataType = BooleanType
+
+  override def bind(f: (Expression, Seq[(DataType, Boolean)]) => LambdaFunction): ArrayExists = {
+    val ArrayType(elementType, containsNull) = argument.dataType
+    copy(
+      function = f(
+        function,
+        (elementType, containsNull) :: Nil
+      )
+    )
+  }
+
+  @transient lazy val LambdaFunction(_, Seq(elementVar: NamedLambdaVariable), _) = function
+
+  override def nullSafeEval(inputRow: InternalRow, argumentValue: Any): Any = {
+    val arr    = argumentValue.asInstanceOf[ArrayData]
+    val f      = functionForEval
+    var exists = false
+    var i      = 0
+    while (i < arr.numElements && !exists) {
+      elementVar.value.set(
+        arr.get(
+          i,
+          elementVar.dataType
+        )
+      )
+      if (f.eval(inputRow).asInstanceOf[Boolean]) {
+        exists = true
+      }
+      i += 1
+    }
+    exists
+  }
+
+  override def prettyName: String = "exists"
+}
+
+/**
+ * Applies a binary operator to a start value and all elements in the array.
+ */
+@ExpressionDescription(
+  usage = """
+      _FUNC_(expr, start, merge, finish) - Applies a binary operator to an initial state and all
+      elements in the array, and reduces this to a single state. The final state is converted
+      into the final result by applying a finish function.
+    """,
+  examples = """
+    Examples:
+      > SELECT _FUNC_(array(1, 2, 3), 0, (acc, x) -> acc + x);
+       6
+      > SELECT _FUNC_(array(1, 2, 3), 0, (acc, x) -> acc + x, acc -> acc * 10);
+       60
+  """,
+  since = "2.4.0"
+)
+case class ArrayAggregate(argument: Expression, zero: Expression, merge: Expression, finish: Expression) extends HigherOrderFunction with CodegenFallback {
+
+  def this(argument: Expression, zero: Expression, merge: Expression) = {
+    this(
+      argument,
+      zero,
+      merge,
+      LambdaFunction.identity
+    )
+  }
+
+  override def arguments: Seq[Expression] = argument :: zero :: Nil
+
+  override def argumentTypes: Seq[AbstractDataType] = ArrayType :: AnyDataType :: Nil
+
+  override def functions: Seq[Expression] = merge :: finish :: Nil
+
+  override def functionTypes: Seq[AbstractDataType] = zero.dataType :: AnyDataType :: Nil
+
+  override def nullable: Boolean = argument.nullable || finish.nullable
+
+  override def dataType: DataType = finish.dataType
+
+  override def checkInputDataTypes(): TypeCheckResult = {
+    checkArgumentDataTypes() match {
+      case TypeCheckResult.TypeCheckSuccess =>
+        if (!DataType.equalsStructurally(
+              zero.dataType,
+              merge.dataType,
+              ignoreNullability = true
+            )) {
+          TypeCheckResult.TypeCheckFailure(
+            s"argument 3 requires ${zero.dataType.simpleString} type, " +
+            s"however, '${merge.sql}' is of ${merge.dataType.catalogString} type."
+          )
+        } else {
+          TypeCheckResult.TypeCheckSuccess
+        }
+      case failure => failure
+    }
+  }
+
+  override def bind(f: (Expression, Seq[(DataType, Boolean)]) => LambdaFunction): ArrayAggregate = {
+    // Be very conservative with nullable. We cannot be sure that the accumulator does not
+    // evaluate to null. So we always set nullable to true here.
+    val ArrayType(elementType, containsNull) = argument.dataType
+    val acc                                  = zero.dataType -> true
+    val newMerge = f(
+      merge,
+      acc :: (elementType, containsNull) :: Nil
+    )
+    val newFinish = f(
+      finish,
+      acc :: Nil
+    )
+    copy(
+      merge = newMerge,
+      finish = newFinish
+    )
+  }
+
+  @transient lazy val LambdaFunction(_, Seq(accForMergeVar: NamedLambdaVariable, elementVar: NamedLambdaVariable), _) = merge
+  @transient lazy val LambdaFunction(_, Seq(accForFinishVar: NamedLambdaVariable), _)                                 = finish
+
+  override def eval(input: InternalRow): Any = {
+    val arr = argument.eval(input).asInstanceOf[ArrayData]
+    if (arr == null) {
+      null
+    } else {
+      val Seq(mergeForEval, finishForEval) = functionsForEval
+      accForMergeVar.value.set(zero.eval(input))
+      var i = 0
+      while (i < arr.numElements()) {
+        elementVar.value.set(
+          arr.get(
+            i,
+            elementVar.dataType
+          )
+        )
+        accForMergeVar.value.set(mergeForEval.eval(input))
+        i += 1
+      }
+      accForFinishVar.value.set(accForMergeVar.value.get)
+      finishForEval.eval(input)
+    }
+  }
+
+  override def prettyName: String = "aggregate"
+}
+
+// scalastyle:off line.size.limit
+@ExpressionDescription(
+  usage = "_FUNC_(left, right, func) - Merges the two given arrays, element-wise, into a single array using function. If one array is shorter, nulls are appended at the end to match the length of the longer array, before applying function.",
+  examples = """
+    Examples:
+      > SELECT _FUNC_(array(1, 2, 3), array('a', 'b', 'c'), (x, y) -> (y, x));
+       [{"y":"a","x":1},{"y":"b","x":2},{"y":"c","x":3}]
+      > SELECT _FUNC_(array(1, 2), array(3, 4), (x, y) -> x + y);
+       [4,6]
+      > SELECT _FUNC_(array('a', 'b', 'c'), array('d', 'e', 'f'), (x, y) -> concat(x, y));
+       ["ad","be","cf"]
+  """,
+  since = "2.4.0"
+)
+// scalastyle:on line.size.limit
+case class ZipWith(left: Expression, right: Expression, function: Expression) extends HigherOrderFunction with CodegenFallback {
+
+  def functionForEval: Expression = functionsForEval.head
+
+  override def arguments: Seq[Expression] = left :: right :: Nil
+
+  override def argumentTypes: Seq[AbstractDataType] = ArrayType :: ArrayType :: Nil
+
+  override def functions: Seq[Expression] = List(function)
+
+  override def functionTypes: Seq[AbstractDataType] = AnyDataType :: Nil
+
+  override def dataType: ArrayType =
+    ArrayType(
+      function.dataType,
+      function.nullable
+    )
+
+  override def bind(f: (Expression, Seq[(DataType, Boolean)]) => LambdaFunction): ZipWith = {
+    val ArrayType(leftElementType, _)  = left.dataType
+    val ArrayType(rightElementType, _) = right.dataType
+    copy(
+      function = f(
+        function,
+        (leftElementType, true) :: (rightElementType, true) :: Nil
+      )
+    )
+  }
+
+  @transient lazy val LambdaFunction(_, Seq(leftElemVar: NamedLambdaVariable, rightElemVar: NamedLambdaVariable), _) = function
+
+  override def eval(input: InternalRow): Any = {
+    val leftArr = left.eval(input).asInstanceOf[ArrayData]
+    if (leftArr == null) {
+      null
+    } else {
+      val rightArr = right.eval(input).asInstanceOf[ArrayData]
+      if (rightArr == null) {
+        null
+      } else {
+        val resultLength = math.max(
+          leftArr.numElements(),
+          rightArr.numElements()
+        )
+        val f      = functionForEval
+        val result = new GenericArrayData(new Array[Any](resultLength))
+        var i      = 0
+        while (i < resultLength) {
+          if (i < leftArr.numElements()) {
+            leftElemVar.value.set(
+              leftArr.get(
+                i,
+                leftElemVar.dataType
+              )
+            )
+          } else {
+            leftElemVar.value.set(null)
+          }
+          if (i < rightArr.numElements()) {
+            rightElemVar.value.set(
+              rightArr.get(
+                i,
+                rightElemVar.dataType
+              )
+            )
+          } else {
+            rightElemVar.value.set(null)
+          }
+          result.update(
+            i,
+            f.eval(input)
+          )
+          i += 1
+        }
+        result
+      }
+    }
+  }
+
+  override def prettyName: String = "zip_with"
+}

--- a/src/test/scala/com/github/mrpowers/spark/daria/sql/HigherOrderFunctionsTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/daria/sql/HigherOrderFunctionsTest.scala
@@ -1,0 +1,1255 @@
+package com.github.mrpowers.spark.daria.sql
+
+import utest._
+
+import org.apache.spark.sql._
+import org.apache.spark.sql.functions._
+import com.github.mrpowers.spark.daria.sql.functions._
+
+object HigherOrderFunctionsTest extends TestSuite with SparkSessionTestWrapper {
+
+  def checkAnswer(ds: Dataset[_], expected: Seq[Row]) = {
+    val actual = ds.collect.toSeq
+    assert(actual == expected)
+  }
+  lazy val s = spark
+
+  val tests = Tests {
+    "transform" - {
+      "handle arrays of primitive types not containing null" - {
+        val s = spark; import s.implicits._
+        val df = Seq(
+          Seq(
+            1,
+            9,
+            8,
+            7
+          ),
+          Seq(
+            5,
+            8,
+            9,
+            7,
+            2
+          ),
+          Seq.empty,
+          null
+        ).toDF("i")
+        checkAnswer(
+          df.select(
+            transform(
+              df("i"),
+              x => x + 1
+            )
+          ),
+          Seq(
+            Row(
+              Seq(
+                2,
+                10,
+                9,
+                8
+              )
+            ),
+            Row(
+              Seq(
+                6,
+                9,
+                10,
+                8,
+                3
+              )
+            ),
+            Row(Seq.empty),
+            Row(null)
+          )
+        )
+        checkAnswer(
+          df.select(
+            transform(
+              df("i"),
+              (x, i) => x + i
+            )
+          ),
+          Seq(
+            Row(
+              Seq(
+                1,
+                10,
+                10,
+                10
+              )
+            ),
+            Row(
+              Seq(
+                5,
+                9,
+                11,
+                10,
+                6
+              )
+            ),
+            Row(Seq.empty),
+            Row(null)
+          )
+        )
+      }
+      "handle arrays of primitive types containing null" - {
+        val s = spark; import s.implicits._
+        val df = Seq[Seq[Integer]](
+          Seq(
+            1,
+            9,
+            8,
+            null,
+            7
+          ),
+          Seq(
+            5,
+            null,
+            8,
+            9,
+            7,
+            2
+          ),
+          Seq.empty,
+          null
+        ).toDF("i")
+        checkAnswer(
+          df.select(
+            transform(
+              df("i"),
+              x => x + 1
+            )
+          ),
+          Seq(
+            Row(
+              Seq(
+                2,
+                10,
+                9,
+                null,
+                8
+              )
+            ),
+            Row(
+              Seq(
+                6,
+                null,
+                9,
+                10,
+                8,
+                3
+              )
+            ),
+            Row(Seq.empty),
+            Row(null)
+          )
+        )
+        checkAnswer(
+          df.select(
+            transform(
+              df("i"),
+              (x, i) => x + i
+            )
+          ),
+          Seq(
+            Row(
+              Seq(
+                1,
+                10,
+                10,
+                null,
+                11
+              )
+            ),
+            Row(
+              Seq(
+                5,
+                null,
+                10,
+                12,
+                11,
+                7
+              )
+            ),
+            Row(Seq.empty),
+            Row(null)
+          )
+        )
+      }
+      "handle arrays of non primitive types" - {
+        val s = spark; import s.implicits._
+        val df = Seq(
+          Seq(
+            "c",
+            "a",
+            "b"
+          ),
+          Seq(
+            "b",
+            null,
+            "c",
+            null
+          ),
+          Seq.empty,
+          null
+        ).toDF("s")
+        checkAnswer(
+          df.select(
+            transform(
+              df("s"),
+              x =>
+                concat(
+                  x,
+                  x
+              )
+            )
+          ),
+          Seq(
+            Row(
+              Seq(
+                "cc",
+                "aa",
+                "bb"
+              )
+            ),
+            Row(
+              Seq(
+                "bb",
+                null,
+                "cc",
+                null
+              )
+            ),
+            Row(Seq.empty),
+            Row(null)
+          )
+        )
+        checkAnswer(
+          df.select(
+            transform(
+              df("s"),
+              (x, i) =>
+                concat(
+                  x,
+                  i
+              )
+            )
+          ),
+          Seq(
+            Row(
+              Seq(
+                "c0",
+                "a1",
+                "b2"
+              )
+            ),
+            Row(
+              Seq(
+                "b0",
+                null,
+                "c2",
+                null
+              )
+            ),
+            Row(Seq.empty),
+            Row(null)
+          )
+        )
+      }
+      "handle special cases" - {
+        val s = spark; import s.implicits._
+        val df = Seq(
+          Seq(
+            "c",
+            "a",
+            "b"
+          ),
+          Seq(
+            "b",
+            null,
+            "c",
+            null
+          ),
+          Seq.empty,
+          null
+        ).toDF("arg")
+        checkAnswer(
+          df.select(
+            transform(
+              df("arg"),
+              arg => arg
+            )
+          ),
+          Seq(
+            Row(
+              Seq(
+                "c",
+                "a",
+                "b"
+              )
+            ),
+            Row(
+              Seq(
+                "b",
+                null,
+                "c",
+                null
+              )
+            ),
+            Row(Seq.empty),
+            Row(null)
+          )
+        )
+        checkAnswer(
+          df.select(
+            transform(
+              df("arg"),
+              _ => df("arg")
+            )
+          ),
+          Seq(
+            Row(
+              Seq(
+                Seq(
+                  "c",
+                  "a",
+                  "b"
+                ),
+                Seq(
+                  "c",
+                  "a",
+                  "b"
+                ),
+                Seq(
+                  "c",
+                  "a",
+                  "b"
+                )
+              )
+            ),
+            Row(
+              Seq(
+                Seq(
+                  "b",
+                  null,
+                  "c",
+                  null
+                ),
+                Seq(
+                  "b",
+                  null,
+                  "c",
+                  null
+                ),
+                Seq(
+                  "b",
+                  null,
+                  "c",
+                  null
+                ),
+                Seq(
+                  "b",
+                  null,
+                  "c",
+                  null
+                )
+              )
+            ),
+            Row(Seq.empty),
+            Row(null)
+          )
+        )
+        checkAnswer(
+          df.select(
+            transform(
+              df("arg"),
+              x =>
+                concat(
+                  df("arg"),
+                  array(x)
+              )
+            )
+          ),
+          Seq(
+            Row(
+              Seq(
+                Seq(
+                  "c",
+                  "a",
+                  "b",
+                  "c"
+                ),
+                Seq(
+                  "c",
+                  "a",
+                  "b",
+                  "a"
+                ),
+                Seq(
+                  "c",
+                  "a",
+                  "b",
+                  "b"
+                )
+              )
+            ),
+            Row(
+              Seq(
+                Seq(
+                  "b",
+                  null,
+                  "c",
+                  null,
+                  "b"
+                ),
+                Seq(
+                  "b",
+                  null,
+                  "c",
+                  null,
+                  null
+                ),
+                Seq(
+                  "b",
+                  null,
+                  "c",
+                  null,
+                  "c"
+                ),
+                Seq(
+                  "b",
+                  null,
+                  "c",
+                  null,
+                  null
+                )
+              )
+            ),
+            Row(Seq.empty),
+            Row(null)
+          )
+        )
+      }
+    }
+    "exists" - {
+      "handle arrays of primtive types not containing null" - {
+        import s.implicits._
+        val df = Seq(
+          Seq(
+            1,
+            9,
+            8,
+            7
+          ),
+          Seq(
+            5,
+            9,
+            7
+          ),
+          Seq.empty,
+          null
+        ).toDF("i")
+        checkAnswer(
+          df.select(
+            exists(
+              df("i"),
+              _ % 2 === 0
+            )
+          ),
+          Seq(
+            Row(true),
+            Row(false),
+            Row(false),
+            Row(null)
+          )
+        )
+      }
+      "handle arrays of primitive types containing null" - {
+        import s.implicits._
+        val df = Seq[Seq[Integer]](
+          Seq(
+            1,
+            9,
+            8,
+            null,
+            7
+          ),
+          Seq(
+            5,
+            null,
+            null,
+            9,
+            7,
+            null
+          ),
+          Seq.empty,
+          null
+        ).toDF("i")
+        checkAnswer(
+          df.select(
+            exists(
+              df("i"),
+              _ % 2 === 0
+            )
+          ),
+          Seq(
+            Row(true),
+            Row(false),
+            Row(false),
+            Row(null)
+          )
+        )
+      }
+      "handle arrays of non primitive types" - {
+        import s.implicits._
+        val df = Seq(
+          Seq(
+            "c",
+            "a",
+            "b"
+          ),
+          Seq(
+            "b",
+            null,
+            "c",
+            null
+          ),
+          Seq.empty,
+          null
+        ).toDF("s")
+        checkAnswer(
+          df.select(
+            exists(
+              df("s"),
+              x => x.isNull
+            )
+          ),
+          Seq(
+            Row(false),
+            Row(true),
+            Row(false),
+            Row(null)
+          )
+        )
+      }
+      "not handle invalid inputs" - {
+        import s.implicits._
+        val df = Seq(
+          (
+            Seq(
+              "c",
+              "a",
+              "b"
+            ),
+            1
+          ),
+          (
+            Seq(
+              "b",
+              null,
+              "c",
+              null
+            ),
+            2
+          ),
+          (Seq.empty, 3),
+          (null, 4)
+        ).toDF(
+          "s",
+          "i"
+        )
+        val ex2a = intercept[MatchError] {
+          df.select(
+            exists(
+              df("i"),
+              x => x
+            )
+          )
+        }
+        assert(ex2a.getMessage.contains("IntegerType"))
+        val ex3a = intercept[AnalysisException] {
+          df.select(
+            exists(
+              df("s"),
+              x => x
+            )
+          )
+        }
+        assert(ex3a.getMessage.contains("data type mismatch: argument 2 requires boolean type"))
+      }
+    }
+    "filter" - {
+      "handle arrays of primitive types not containing null" - {
+        import s.implicits._
+        val df = Seq(
+          Seq(
+            1,
+            9,
+            8,
+            7
+          ),
+          Seq(
+            5,
+            8,
+            9,
+            7,
+            2
+          ),
+          Seq.empty,
+          null
+        ).toDF("i")
+        checkAnswer(
+          df.select(
+            filter(
+              df("i"),
+              _ % 2 === 0
+            )
+          ),
+          Seq(
+            Row(Seq(8)),
+            Row(
+              Seq(
+                8,
+                2
+              )
+            ),
+            Row(Seq.empty),
+            Row(null)
+          )
+        )
+      }
+      "handle arrays of primitive types containing null" - {
+        import s.implicits._
+        val df = Seq[Seq[Integer]](
+          Seq(
+            1,
+            9,
+            8,
+            null,
+            7
+          ),
+          Seq(
+            5,
+            null,
+            8,
+            9,
+            7,
+            2
+          ),
+          Seq.empty,
+          null
+        ).toDF("i")
+        checkAnswer(
+          df.select(
+            filter(
+              df("i"),
+              _ % 2 === 0
+            )
+          ),
+          Seq(
+            Row(Seq(8)),
+            Row(
+              Seq(
+                8,
+                2
+              )
+            ),
+            Row(Seq.empty),
+            Row(null)
+          )
+        )
+      }
+      "handle arrays of non primitive types" - {
+        import s.implicits._
+        val df = Seq(
+          Seq(
+            "c",
+            "a",
+            "b"
+          ),
+          Seq(
+            "b",
+            null,
+            "c",
+            null
+          ),
+          Seq.empty,
+          null
+        ).toDF("s")
+        checkAnswer(
+          df.select(
+            filter(
+              df("s"),
+              x => x.isNotNull
+            )
+          ),
+          Seq(
+            Row(
+              Seq(
+                "c",
+                "a",
+                "b"
+              )
+            ),
+            Row(
+              Seq(
+                "b",
+                "c"
+              )
+            ),
+            Row(Seq.empty),
+            Row(null)
+          )
+        )
+      }
+      "not handle invalid cases" - {
+        import s.implicits._
+        val df = Seq(
+          (
+            Seq(
+              "c",
+              "a",
+              "b"
+            ),
+            1
+          ),
+          (
+            Seq(
+              "b",
+              null,
+              "c",
+              null
+            ),
+            2
+          ),
+          (Seq.empty, 3),
+          (null, 4)
+        ).toDF(
+          "s",
+          "i"
+        )
+        val ex2a = intercept[MatchError] {
+          df.select(
+            filter(
+              df("i"),
+              x => x
+            )
+          )
+        }
+        assert(ex2a.getMessage.contains("IntegerType"))
+        val ex3a = intercept[AnalysisException] {
+          df.select(
+            filter(
+              df("s"),
+              x => x
+            )
+          )
+        }
+        assert(ex3a.getMessage.contains("data type mismatch: argument 2 requires boolean type"))
+      }
+    }
+    "aggregate" - {
+      "handle arrays of primitive types not containing null" - {
+        import s.implicits._
+        val df = Seq(
+          Seq(
+            1,
+            9,
+            8,
+            7
+          ),
+          Seq(
+            5,
+            8,
+            9,
+            7,
+            2
+          ),
+          Seq.empty,
+          null
+        ).toDF("i")
+        checkAnswer(
+          df.select(
+            aggregate(
+              df("i"),
+              lit(0),
+              (acc, x) => acc + x
+            )
+          ),
+          Seq(
+            Row(25),
+            Row(31),
+            Row(0),
+            Row(null)
+          )
+        )
+        checkAnswer(
+          df.select(
+            aggregate(
+              df("i"),
+              lit(0),
+              (acc, x) => acc + x,
+              _ * 10
+            )
+          ),
+          Seq(
+            Row(250),
+            Row(310),
+            Row(0),
+            Row(null)
+          )
+        )
+      }
+      "handle arrays of primitive types containing null" - {
+        import s.implicits._
+        val df = Seq[Seq[Integer]](
+          Seq(
+            1,
+            9,
+            8,
+            7
+          ),
+          Seq(
+            5,
+            null,
+            8,
+            9,
+            7,
+            2
+          ),
+          Seq.empty,
+          null
+        ).toDF("i")
+        checkAnswer(
+          df.select(
+            aggregate(
+              df("i"),
+              lit(0),
+              (acc, x) => acc + x
+            )
+          ),
+          Seq(
+            Row(25),
+            Row(null),
+            Row(0),
+            Row(null)
+          )
+        )
+        checkAnswer(
+          df.select(
+            aggregate(
+              df("i"),
+              lit(0),
+              (acc, x) => acc + x,
+              acc =>
+                coalesce(
+                  acc,
+                  lit(0)
+                ) * 10
+            )
+          ),
+          Seq(
+            Row(250),
+            Row(0),
+            Row(0),
+            Row(null)
+          )
+        )
+      }
+      "handle arrays of non primitive types" - {
+        import s.implicits._
+        val df = Seq(
+          (
+            Seq(
+              "c",
+              "a",
+              "b"
+            ),
+            "a"
+          ),
+          (
+            Seq(
+              "b",
+              null,
+              "c",
+              null
+            ),
+            "b"
+          ),
+          (Seq.empty, "c"),
+          (null, "d")
+        ).toDF(
+          "ss",
+          "s"
+        )
+        checkAnswer(
+          df.select(
+            aggregate(
+              df("ss"),
+              df("s"),
+              (acc, x) =>
+                concat(
+                  acc,
+                  x
+              )
+            )
+          ),
+          Seq(
+            Row("acab"),
+            Row(null),
+            Row("c"),
+            Row(null)
+          )
+        )
+        checkAnswer(
+          df.select(
+            aggregate(
+              df("ss"),
+              df("s"),
+              (acc, x) =>
+                concat(
+                  acc,
+                  x
+              ),
+              acc =>
+                coalesce(
+                  acc,
+                  lit("")
+              )
+            )
+          ),
+          Seq(
+            Row("acab"),
+            Row(""),
+            Row("c"),
+            Row(null)
+          )
+        )
+      }
+      "not handle invalid cases" - {
+        import s.implicits._
+        val df = Seq(
+          (
+            Seq(
+              "c",
+              "a",
+              "b"
+            ),
+            1
+          ),
+          (
+            Seq(
+              "b",
+              null,
+              "c",
+              null
+            ),
+            2
+          ),
+          (Seq.empty, 3),
+          (null, 4)
+        ).toDF(
+          "s",
+          "i"
+        )
+        val ex3a = intercept[MatchError] {
+          df.select(
+            aggregate(
+              df("i"),
+              lit(0),
+              (acc, x) => x
+            )
+          )
+        }
+        assert(ex3a.getMessage.contains("IntegerType"))
+        val ex4a = intercept[AnalysisException] {
+          df.select(
+            aggregate(
+              df("s"),
+              lit(0),
+              (acc, x) => x
+            )
+          )
+        }
+        assert(ex4a.getMessage.contains("data type mismatch: argument 3 requires int type"))
+      }
+    }
+    "zip_with" - {
+      "handle arrays of primitive types" - {
+        import s.implicits._
+        val df1 = Seq[(Seq[Integer], Seq[Integer])](
+          (
+            Seq(
+              9001,
+              9002,
+              9003
+            ),
+            Seq(
+              4,
+              5,
+              6
+            )
+          ),
+          (
+            Seq(
+              1,
+              2
+            ),
+            Seq(
+              3,
+              4
+            )
+          ),
+          (Seq.empty, Seq.empty),
+          (null, null)
+        ).toDF(
+          "val1",
+          "val2"
+        )
+        val df2 = Seq[(Seq[Integer], Seq[Long])](
+          (
+            Seq(
+              1,
+              null,
+              3
+            ),
+            Seq(
+              1L,
+              2L
+            )
+          ),
+          (
+            Seq(
+              1,
+              2,
+              3
+            ),
+            Seq(
+              4L,
+              11L
+            )
+          )
+        ).toDF(
+          "val1",
+          "val2"
+        )
+        val expectedValue1 = Seq(
+          Row(
+            Seq(
+              9005,
+              9007,
+              9009
+            )
+          ),
+          Row(
+            Seq(
+              4,
+              6
+            )
+          ),
+          Row(Seq.empty),
+          Row(null)
+        )
+        checkAnswer(
+          df1.select(
+            zip_with(
+              df1("val1"),
+              df1("val2"),
+              (x, y) => x + y
+            )
+          ),
+          expectedValue1
+        )
+        val expectedValue2 = Seq(
+          Row(
+            Seq(
+              Row(
+                1L,
+                1
+              ),
+              Row(
+                2L,
+                null
+              ),
+              Row(
+                null,
+                3
+              )
+            )
+          ),
+          Row(
+            Seq(
+              Row(
+                4L,
+                1
+              ),
+              Row(
+                11L,
+                2
+              ),
+              Row(
+                null,
+                3
+              )
+            )
+          )
+        )
+        checkAnswer(
+          df2.select(
+            zip_with(
+              df2("val1"),
+              df2("val2"),
+              (x, y) =>
+                struct(
+                  y,
+                  x
+              )
+            )
+          ),
+          expectedValue2
+        )
+      }
+      "handle arrays of non primtive types" - {
+        import s.implicits._
+        val df = Seq(
+          (
+            Seq("a"),
+            Seq(
+              "x",
+              "y",
+              "z"
+            )
+          ),
+          (
+            Seq(
+              "a",
+              null
+            ),
+            Seq(
+              "x",
+              "y"
+            )
+          ),
+          (Seq.empty[String], Seq.empty[String]),
+          (
+            Seq(
+              "a",
+              "b",
+              "c"
+            ),
+            null
+          )
+        ).toDF(
+          "val1",
+          "val2"
+        )
+        val expectedValue1 = Seq(
+          Row(
+            Seq(
+              Row(
+                "x",
+                "a"
+              ),
+              Row(
+                "y",
+                null
+              ),
+              Row(
+                "z",
+                null
+              )
+            )
+          ),
+          Row(
+            Seq(
+              Row(
+                "x",
+                "a"
+              ),
+              Row(
+                "y",
+                null
+              )
+            )
+          ),
+          Row(Seq.empty),
+          Row(null)
+        )
+        checkAnswer(
+          df.select(
+            zip_with(
+              df("val1"),
+              df("val2"),
+              (x, y) =>
+                struct(
+                  y,
+                  x
+              )
+            )
+          ),
+          expectedValue1
+        )
+      }
+      "not handle invalid cases" - {
+        import s.implicits._
+        val df = Seq(
+          (
+            Seq(
+              "c",
+              "a",
+              "b"
+            ),
+            Seq(
+              "x",
+              "y",
+              "z"
+            ),
+            1
+          ),
+          (
+            Seq(
+              "b",
+              null,
+              "c",
+              null
+            ),
+            Seq("x"),
+            2
+          ),
+          (
+            Seq.empty,
+            Seq(
+              "x",
+              "z"
+            ),
+            3
+          ),
+          (
+            null,
+            Seq(
+              "x",
+              "z"
+            ),
+            4
+          )
+        ).toDF(
+          "a1",
+          "a2",
+          "i"
+        )
+        val ex3a = intercept[MatchError] {
+          df.select(
+            zip_with(
+              df("i"),
+              df("a2"),
+              (acc, x) => x
+            )
+          )
+        }
+        assert(ex3a.getMessage.contains("IntegerType"))
+      }
+    }
+  }
+}


### PR DESCRIPTION
Based on changes in here https://github.com/apache/spark/pull/24232.

Not ready for merge, I think there are some bugs not caught by the test yet. Need to investigate later.

Also need to test for < spark 2.4, but it should be work since we vendor spark's implementations under `org.apache.spark.sql.catalyst.expressions.daria` instead of referencing the ones spark provides under `org.apache.spark.sql.catalyst.expressions` in spark >= 2.4

cc: @manuzhang 