### PR TITLE
WIP: adding safeGetXXX functions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,10 +8,10 @@ crossScalaVersions := Seq("2.11.12", "2.12.10")
 scalaVersion := "2.11.12"
 val sparkVersion = "2.4.4"
 
-libraryDependencies += "org.apache.spark" %% "spark-sql" % sparkVersion % "provided"
-libraryDependencies += "org.apache.spark" %% "spark-mllib" % sparkVersion % "provided"
-libraryDependencies += "com.github.mrpowers" %% "spark-fast-tests" % "0.21.3" % "test"
-libraryDependencies += "com.lihaoyi" %% "utest" % "0.6.3" % "test"
+libraryDependencies += "org.apache.spark"    %% "spark-sql"        % sparkVersion % "provided"
+libraryDependencies += "org.apache.spark"    %% "spark-mllib"      % sparkVersion % "provided"
+libraryDependencies += "com.github.mrpowers" %% "spark-fast-tests" % "0.21.3"     % "test"
+libraryDependencies += "com.lihaoyi"         %% "utest"            % "0.6.3"      % "test"
 testFrameworks += new TestFramework("com.github.mrpowers.spark.daria.CustomFramework")
 
 artifactName := { (sv: ScalaVersion, module: ModuleID, artifact: Artifact) =>
@@ -38,4 +38,4 @@ publishMavenStyle := true
 
 publishTo := sonatypePublishToBundle.value
 
-Global/useGpgPinentry := true
+Global / useGpgPinentry := true

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,6 +7,6 @@ resolvers += Resolver.bintrayIvyRepo(
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.0")
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
+addSbtPlugin("com.eed3si9n"   % "sbt-assembly" % "0.15.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.4")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
+addSbtPlugin("com.jsuereth"   % "sbt-pgp"      % "2.0.1")

--- a/src/main/scala/com/github/mrpowers/spark/daria/sql/RowHelpers.scala
+++ b/src/main/scala/com/github/mrpowers/spark/daria/sql/RowHelpers.scala
@@ -1,0 +1,235 @@
+package com.github.mrpowers.spark.daria.sql
+
+import java.lang
+import java.sql.{Date, Timestamp}
+import java.text.SimpleDateFormat
+
+import org.apache.spark.sql.Row
+
+object RowHelpers {
+
+  /**
+   * Some utilities to avoid class cast exception while retrieving
+   * typed cells out of a row.
+   *
+   * @param row
+   * @tparam T
+   */
+  implicit class PimpedRow[T](val row: Row) extends AnyVal {
+
+    /**
+     * retrieves an Int providing meaningful conversions
+     *
+     * @param fieldIndex
+     * @return
+     */
+    def safeGetInt(fieldIndex: Int): Int = {
+      val value = row.get(fieldIndex)
+      value match {
+        case a: java.lang.Integer    => a.toInt
+        case a: java.lang.Long       => a.toInt
+        case a: java.lang.Byte       => a.toInt
+        case a: java.lang.Short      => a.toInt
+        case a: java.math.BigDecimal => a.intValue()
+        case a: java.lang.String     => a.toInt
+        case a: java.sql.Timestamp   => a.getTime.toInt
+        case a: java.sql.Date        => a.getTime.toInt
+
+        /**
+         * because null.asInstanceOf[Int] gives.....0 !
+         */
+        case null => throw new NullPointerException(s"$fieldIndex")
+        case _    => value.asInstanceOf[Int]
+      }
+    }
+
+    /**
+     * retrieves an Int providing meaningful conversions
+     *
+     * @param fieldName
+     * @return
+     */
+    def safeGetInt(fieldName: String): Int = safeGetInt(row.fieldIndex(fieldName))
+
+    /**
+     * retrieves a long providing a meaningful conversion
+     *
+     * @param fieldIndex
+     * @return
+     */
+    def safeGetLong(fieldIndex: Int): Long = {
+      val value = row.get(fieldIndex)
+      value match {
+        case a: Integer              => a.toLong
+        case a: lang.Long            => a.toLong
+        case a: lang.Byte            => a.toLong
+        case a: lang.Short           => a.toLong
+        case a: java.math.BigDecimal => a.longValue()
+        case a: String               => a.toLong
+        case a: Timestamp            => a.getTime
+        case a: Date                 => a.getTime
+
+        /**
+         * because null.asInstanceOf[Int] gives.....0 !
+         */
+        case null => throw new NullPointerException(s"$fieldIndex")
+        case _    => value.asInstanceOf[Long]
+      }
+    }
+
+    /**
+     * retrieves a long providing a meaningful conversion
+     *
+     * @param fieldName
+     * @return
+     */
+    def safeGetLong(fieldName: String): Long = safeGetLong(row.fieldIndex(fieldName))
+
+    /**
+     * Retrieves a string providing a meaningful conversion.
+     *
+     * @param fieldIndex
+     * @return
+     */
+    def safeGetString(fieldIndex: Int): String = {
+      val value = row.get(fieldIndex)
+      if (value == null) null else s"$value"
+    }
+
+    /**
+     * retrieves a string providing a meaningful conversion
+     *
+     * @param fieldName
+     * @return
+     */
+    def safeGetString(fieldName: String): String = safeGetString(row.fieldIndex(fieldName))
+
+    /**
+     * retrieves a timestamp providing a meaningful conversion
+     *
+     * @param fieldIndex
+     * @return
+     */
+    def safeGetTimestamp(fieldIndex: Int): Timestamp = {
+      val value = row.get(fieldIndex)
+      if (value == null) null
+      else {
+        value match {
+          case a: java.lang.Long => new Timestamp(a)
+          case a: java.lang.String =>
+            Timestamp.valueOf(a)
+          case a: java.sql.Date =>
+            new Timestamp(a.getTime)
+          case a: java.sql.Timestamp =>
+            a
+          case _ => value.asInstanceOf[Timestamp]
+        }
+      }
+    }
+
+    /**
+     * retrieves a timestamp providing a meaningful conversion
+     *
+     * @param fieldName
+     * @return
+     */
+    def safeGetTimestamp(fieldName: String): Timestamp = safeGetTimestamp(row.fieldIndex(fieldName))
+
+    /**
+     * retrieves a date providing a meaningful conversion
+     *
+     * @param fieldIndex
+     * @return
+     */
+    def safeGetDate(fieldIndex: Int): Date = {
+      val value = row.get(fieldIndex)
+      if (value == null) null
+      else {
+        value match {
+          case a: java.lang.Long => new Date(a)
+          case a: java.lang.String =>
+            Date.valueOf(a)
+          case a: java.sql.Date =>
+            a
+          case a: java.sql.Timestamp =>
+            new Date(a.getTime)
+          case _ => value.asInstanceOf[Date]
+        }
+      }
+    }
+
+    /**
+     * retrieves a date providing a meaningful conversion
+     *
+     * @param fieldIndex
+     * @return
+     */
+    def safeGetDate(fieldIndex: Int, dateFormat: String): Date = {
+      val value = row.get(fieldIndex)
+      if (value == null) null
+      else {
+        value match {
+          case a: java.lang.Long => new Date(a)
+          case a: java.lang.String =>
+            new java.sql.Date(new SimpleDateFormat(dateFormat).parse(a).getTime)
+          case a: java.sql.Date =>
+            a
+          case a: java.sql.Timestamp =>
+            new Date(a.getTime)
+          case _ => value.asInstanceOf[Date]
+        }
+      }
+    }
+
+    /**
+     * retrieves a timestamp providing a meaningful conversion
+     *
+     * @param fieldName
+     * @return
+     */
+    def safeGetDate(fieldName: String, dateFormat: String): Date = safeGetDate(row.fieldIndex(fieldName), dateFormat)
+
+    /**
+     * retrieves a timestamp providing a meaningful conversion
+     *
+     * @param fieldName
+     * @return
+     */
+    def safeGetDate(fieldName: String): Date = safeGetDate(row.fieldIndex(fieldName))
+
+    /**
+     * retrieves an Double providing meaningful conversions
+     *
+     * @param fieldIndex
+     * @return
+     */
+    def safeGetDouble(fieldIndex: Int): Double = {
+      val value = row.get(fieldIndex)
+      value match {
+        case a: java.lang.Integer    => a.toDouble
+        case a: java.lang.Long       => a.toDouble
+        case a: java.lang.Byte       => a.toDouble
+        case a: java.lang.Short      => a.toDouble
+        case a: java.math.BigDecimal => a.doubleValue()
+        case a: java.lang.String     => a.toDouble
+        case a: java.sql.Timestamp   => a.getTime.toDouble
+        case a: java.sql.Date        => a.getTime.toDouble
+
+        /**
+         * because null.asInstanceOf[Int] gives.....0 !
+         */
+        case null => throw new NullPointerException(s"$fieldIndex")
+        case _    => value.asInstanceOf[Double]
+      }
+    }
+
+    /**
+     * retrieves a double providing a meaningful conversion
+     *
+     * @param fieldName
+     * @return
+     */
+    def safeGetDouble(fieldName: String): Double = safeGetDouble(row.fieldIndex(fieldName))
+
+  }
+}

--- a/src/test/scala/com/github/mrpowers/spark/daria/sql/RowHepersTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/daria/sql/RowHepersTest.scala
@@ -1,0 +1,112 @@
+package com.github.mrpowers.spark.daria.sql
+
+import java.sql.Date
+import java.util.Calendar
+
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.functions.{col, struct, udf}
+import org.apache.spark.sql.{DataFrame, Row}
+import utest._
+
+object RowHepersTest extends TestSuite with SparkSessionTestWrapper {
+
+  import spark.implicits._
+
+  val tests = Tests {
+
+    "safeGetDate" - {
+
+      "gets safely a date from a dataframe when dealing with a java.sql.Date" - {
+        val data = List(
+          HasReadingDate(Date.valueOf("2019-02-04"), 1),
+          HasReadingDate(Date.valueOf("2019-02-05"), 1),
+          HasReadingDate(Date.valueOf("2019-02-06"), 1),
+          HasReadingDate(Date.valueOf("2019-02-07"), 1),
+          HasReadingDate(Date.valueOf("2019-02-08"), 1),
+          HasReadingDate(Date.valueOf("2019-02-09"), 1),
+          HasReadingDate(Date.valueOf("2019-02-10"), 1)
+        )
+        val frame = data.toDF()
+
+        val value = frame.transform(AddWeekendStage).as[HasReadingDateWithWeekend].collect().toSet
+
+        assert(
+          Set(
+            HasReadingDateWithWeekend(Date.valueOf("2019-02-04"), 1, 0),
+            HasReadingDateWithWeekend(Date.valueOf("2019-02-05"), 1, 0),
+            HasReadingDateWithWeekend(Date.valueOf("2019-02-06"), 1, 0),
+            HasReadingDateWithWeekend(Date.valueOf("2019-02-07"), 1, 0),
+            HasReadingDateWithWeekend(Date.valueOf("2019-02-08"), 1, 0),
+            HasReadingDateWithWeekend(Date.valueOf("2019-02-09"), 1, 1),
+            HasReadingDateWithWeekend(Date.valueOf("2019-02-10"), 1, 1)
+          ) == value
+        )
+      }
+
+      "gets safely a date from a dataframe when dealing with a String" - {
+        val data = List(
+          HasReadingDateString("2019-02-04", 1),
+          HasReadingDateString("2019-02-05", 1),
+          HasReadingDateString("2019-02-06", 1),
+          HasReadingDateString("2019-02-07", 1),
+          HasReadingDateString("2019-02-08", 1),
+          HasReadingDateString("2019-02-09", 1),
+          HasReadingDateString("2019-02-10", 1)
+        )
+        val frame = data.toDF()
+
+        val value = frame.transform(AddWeekendStage).as[HasReadingDateWithWeekend].collect().toSet
+
+        assert(
+          Set(
+            HasReadingDateWithWeekend(Date.valueOf("2019-02-04"), 1, 0),
+            HasReadingDateWithWeekend(Date.valueOf("2019-02-05"), 1, 0),
+            HasReadingDateWithWeekend(Date.valueOf("2019-02-06"), 1, 0),
+            HasReadingDateWithWeekend(Date.valueOf("2019-02-07"), 1, 0),
+            HasReadingDateWithWeekend(Date.valueOf("2019-02-08"), 1, 0),
+            HasReadingDateWithWeekend(Date.valueOf("2019-02-09"), 1, 1),
+            HasReadingDateWithWeekend(Date.valueOf("2019-02-10"), 1, 1)
+          ) == value
+        )
+      }
+
+    }
+  }
+
+}
+
+/**
+ * This function adds an ""is_weekend" column
+ * to the dataframe.
+ * It is able to cope with different dats formats, either true dates or stringified dates (sql formats)
+ */
+case object AddWeekendStage extends (DataFrame => DataFrame) {
+
+  import com.github.mrpowers.spark.daria.sql.RowHelpers._
+
+  override def apply(df: DataFrame): DataFrame = {
+    df.withColumn("is_weekend", isWeekendUDF(struct(col("reference_date"))))
+  }
+
+  def isWeekend(date: Date): Int = {
+    val calendar = Calendar.getInstance
+    calendar.setTime(date)
+    if (calendar.get(Calendar.DAY_OF_WEEK) == Calendar.SATURDAY || calendar.get(Calendar.DAY_OF_WEEK) == Calendar.SUNDAY) 1 else 0
+  }
+
+  /**
+   * using the safeGetDate
+   *
+   * @param row
+   * @return
+   */
+  def isWeekendRow(row: Row): Int =
+    isWeekend(row.safeGetDate(0))
+
+  val isWeekendUDF: UserDefinedFunction = udf(isWeekendRow _)
+
+}
+
+case class HasReadingDate(reference_date: Date, count: Int)
+case class HasReadingDateString(reference_date: String, count: Int)
+case class HasReadingDateWithWeekend(reference_date: Date, count: Int, is_weekend: Int)


### PR DESCRIPTION
This is a Work in progress to show out an idea.

Often times I got issues when trying to do operations on a DataFrame whose column type change (over time or over datasets), and, for multiple reasons, enforcing a schema is harder than leaving it "open" (For example, data frames with a huge number of columns).

This is the case of different, non homogenous datasets that come in different format, such as CSV ( and BTW the automatic schema inference has troubles) Parquet and XLS, and at the same time I should be able to merge, mixx and match these sources.
Eventually the same code should be able to process a column that may either as `java.sql.Date` or a `java.lang.String` for example.

Because of this I found out that it useful to have some `safeGetSomething` where I bake in a smart conversion and avoid getting `ClassCastException`, or write lengthy code to work around it.

I baked these functionalities as implicits to import.
Here the signature is like

```
safeGetDate("may_be_you_are_a_date") // // smart conversion happening.... if nothing is possible.... class cast and pray!
safeGetInt("eventual_int")
safeGetTimestamp
```

But it could also be nicer done with 

```
safeGet[Date] // smart conversion happening.... if nothing is possible.... class cast and pray!
safeGet[Int]
safeGet[TimeStamp]
```

Here I already provided "obvious" conversions between taking in account base ans `sql` types, but eventually the mechanism could be made extensible with `implicits`.
You get and example and a test case with `safeGetDate` to demonstrate the idea.

If you think this idea is valuable I would open a more structured pull request with a more extended test suite.

