### PR TITLE
Add methods to modify column names to camelCase, snakeCase and upperCase

### DIFF
--- a/src/main/scala/com/github/mrpowers/spark/daria/sql/transformations.scala
+++ b/src/main/scala/com/github/mrpowers/spark/daria/sql/transformations.scala
@@ -151,6 +151,18 @@ object transformations {
     modifyColumnNames(stringFun)(df)
   }
 
+  def toSnakeCaseColumns()(df: DataFrame): DataFrame = {
+    modifyColumnNames(com.github.mrpowers.spark.daria.utils.StringHelpers.snakeCaseCatchAll)(df)
+  }
+
+  def camelCaseColumns()(df: DataFrame): DataFrame = {
+    modifyColumnNames(com.github.mrpowers.spark.daria.utils.StringHelpers.snakeCaseToCamelCase)(df)
+  }
+
+  def upperCaseColumns()(df: DataFrame): DataFrame = {
+    modifyColumnNames(com.github.mrpowers.spark.daria.utils.StringHelpers.upperCaseCatchAll)(df)
+  }
+
   def prependToColName(str: String)(df: DataFrame): DataFrame = {
     def stringFun(s: String): String = str + s
     modifyColumnNames(stringFun)(df)

--- a/src/main/scala/com/github/mrpowers/spark/daria/utils/StringHelpers.scala
+++ b/src/main/scala/com/github/mrpowers/spark/daria/utils/StringHelpers.scala
@@ -57,4 +57,20 @@ object StringHelpers {
     str.replaceAll("[,;{}()\n\t=]", "").replaceAll(" ", "_").toLowerCase()
   }
 
+  def titleCase(str: String): String = {
+    str.toLowerCase().split(' ').map(_.capitalize).mkString(" ")
+  }
+
+  def snakeCaseCatchAll(str: String): String = toSnakeCase(snakify(str))
+
+  def snakeCaseToCamelCase(str: String): String = {
+    val words = snakeCaseCatchAll(str)
+      .split('_')
+      .map(_.capitalize)
+
+    (words.head.toLowerCase() ++ words.tail).mkString("")
+  }
+
+  def upperCaseCatchAll(str: String): String = snakeCaseCatchAll(str).toUpperCase
+
 }

--- a/src/test/scala/com/github/mrpowers/spark/daria/sql/TransformationsTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/daria/sql/TransformationsTest.scala
@@ -219,6 +219,243 @@ object TransformationsTest extends TestSuite with DataFrameComparer with ColumnC
 
     }
 
+    "snakifyColumns catch-all scenarios" - {
+
+      val sourceDF = spark.createDF(
+        List(("mixed case with spaces",
+          "mixed case with spaces",
+          "multi-spaces",
+          "word with a capitalized letter",
+          "BiH",
+          "a_b_c",
+          "de_f",
+          "cr_ay",
+          "col_four",
+          "colfive",
+          "col_sevenAh",
+          "HOWABOUTTHIS",
+          "thisOne",
+          "ORACLE_CASING"
+        )),
+        List(
+          ("A b C", StringType, true),
+          ("de F", StringType, true),
+          ("cr   ay", StringType, true),
+          ("ThIs", StringType, true),
+          ("BiH", StringType, true),
+          ("a_b_c", StringType, true),
+          ("de_f", StringType, true),
+          ("cr_ay", StringType, true),
+          ("col_four", StringType, true),
+          ("colfive", StringType, true),
+          ("col_sevenAh", StringType, true),
+          ("HOWABOUTTHIS", StringType, true),
+          ("thisOne", StringType, true),
+          ("oracle_casing", StringType, true)
+        )
+      )
+
+      val actualDf = sourceDF.transform(transformations.toSnakeCaseColumns())
+
+      val expectedDF = spark.createDF(
+        List(("mixed case with spaces",
+          "mixed case with spaces",
+          "multi-spaces",
+          "word with a capitalized letter",
+          "BiH",
+          "a_b_c",
+          "de_f",
+          "cr_ay",
+          "col_four",
+          "colfive",
+          "col_sevenAh",
+          "HOWABOUTTHIS",
+          "thisOne",
+          "ORACLE_CASING"
+        )),
+        List(
+          ("a_b_c", StringType, true),
+          ("de_f", StringType, true),
+          ("cr_ay", StringType, true),
+          ("th_is", StringType, true),
+          ("bi_h", StringType, true),
+          ("a_b_c", StringType, true),
+          ("de_f", StringType, true),
+          ("cr_ay", StringType, true),
+          ("col_four", StringType, true),
+          ("colfive", StringType, true),
+          ("col_seven_ah", StringType, true),
+          ("howaboutthis", StringType, true),
+          ("this_one", StringType, true),
+          ("oracle_casing", StringType, true)
+        )
+      )
+
+      assertSmallDataFrameEquality(
+        actualDf,
+        expectedDF
+      )
+
+    }
+
+    "camelCase catch-all scenarios" - {
+
+      val sourceDF = spark.createDF(
+        List(("mixed case with spaces",
+          "mixed case with spaces",
+          "multi-spaces",
+          "word with a capitalized letter",
+          "BiH",
+          "a_b_c",
+          "de_f",
+          "cr_ay",
+          "col_four",
+          "colfive",
+          "col_sevenAh",
+          "HOWABOUTTHIS",
+          "thisOne",
+          "ORACLE_CASING"
+        )),
+        List(
+          ("A b C", StringType, true),
+          ("de F", StringType, true),
+          ("cr   ay", StringType, true),
+          ("ThIs", StringType, true),
+          ("BiH", StringType, true),
+          ("a_b_c", StringType, true),
+          ("de_f", StringType, true),
+          ("cr_ay", StringType, true),
+          ("col_four", StringType, true),
+          ("colfive", StringType, true),
+          ("col_sevenAh", StringType, true),
+          ("HOWABOUTTHIS", StringType, true),
+          ("thisOne", StringType, true),
+          ("oracle_casing", StringType, true)
+        )
+      )
+
+      val actualDf = sourceDF.transform(transformations.camelCaseColumns())
+
+      val expectedDF = spark.createDF(
+        List(("mixed case with spaces",
+          "mixed case with spaces",
+          "multi-spaces",
+          "word with a capitalized letter",
+          "BiH",
+          "a_b_c",
+          "de_f",
+          "cr_ay",
+          "col_four",
+          "colfive",
+          "col_sevenAh",
+          "HOWABOUTTHIS",
+          "thisOne",
+          "ORACLE_CASING"
+        )),
+        List(
+          ("aBC", StringType, true),
+          ("deF", StringType, true),
+          ("crAy", StringType, true),
+          ("thIs", StringType, true),
+          ("biH", StringType, true),
+          ("aBC", StringType, true),
+          ("deF", StringType, true),
+          ("crAy", StringType, true),
+          ("colFour", StringType, true),
+          ("colfive", StringType, true),
+          ("colSevenAh", StringType, true),
+          ("howaboutthis", StringType, true),
+          ("thisOne", StringType, true),
+          ("oracleCasing", StringType, true)
+        )
+      )
+
+      assertSmallDataFrameEquality(
+        actualDf,
+        expectedDF
+      )
+
+    }
+
+    "upperCase catch-all scenarios" - {
+
+      val sourceDF = spark.createDF(
+        List(("mixed case with spaces",
+          "mixed case with spaces",
+          "multi-spaces",
+          "word with a capitalized letter",
+          "BiH",
+          "a_b_c",
+          "de_f",
+          "cr_ay",
+          "col_four",
+          "colfive",
+          "col_sevenAh",
+          "HOWABOUTTHIS",
+          "thisOne",
+          "ORACLE_CASING"
+        )),
+        List(
+          ("A b C", StringType, true),
+          ("de F", StringType, true),
+          ("cr   ay", StringType, true),
+          ("ThIs", StringType, true),
+          ("BiH", StringType, true),
+          ("a_b_c", StringType, true),
+          ("de_f", StringType, true),
+          ("cr_ay", StringType, true),
+          ("col_four", StringType, true),
+          ("colfive", StringType, true),
+          ("col_sevenAh", StringType, true),
+          ("HOWABOUTTHIS", StringType, true),
+          ("thisOne", StringType, true),
+          ("oracle_casing", StringType, true)
+        )
+      )
+
+      val actualDf = sourceDF.transform(transformations.upperCaseColumns())
+
+      val expectedDF = spark.createDF(
+        List(("mixed case with spaces",
+          "mixed case with spaces",
+          "multi-spaces",
+          "word with a capitalized letter",
+          "BiH",
+          "a_b_c",
+          "de_f",
+          "cr_ay",
+          "col_four",
+          "colfive",
+          "col_sevenAh",
+          "HOWABOUTTHIS",
+          "thisOne",
+          "ORACLE_CASING"
+        )),
+        List(
+          ("A_B_C", StringType, true),
+          ("DE_F", StringType, true),
+          ("CR_AY", StringType, true),
+          ("TH_IS", StringType, true),
+          ("BI_H", StringType, true),
+          ("A_B_C", StringType, true),
+          ("DE_F", StringType, true),
+          ("CR_AY", StringType, true),
+          ("COL_FOUR", StringType, true),
+          ("COLFIVE", StringType, true),
+          ("COL_SEVEN_AH", StringType, true),
+          ("HOWABOUTTHIS", StringType, true),
+          ("THIS_ONE", StringType, true),
+          ("ORACLE_CASING", StringType, true)
+        )
+      )
+
+      assertSmallDataFrameEquality(
+        actualDf,
+        expectedDF
+      )
+
+    }
+
     'prependToColName - {
 
       "Prepends a string to all column names" - {


### PR DESCRIPTION
There are two existing methods snakifyColumns/snakeCaseColumns.  Combined the capability to produce catch-all camelCase, upperCase and snakeCase methods.