### PR TITLE
Format sources and add formatting check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,4 +17,4 @@ jobs:
       - uses: actions/checkout@v1
       - uses: olafurpg/setup-scala@v10
       - name: Test
-        run: sbt -Dspark.testVersion=${{ matrix.spark  }} ++${{ matrix.scala }} test
+        run: sbt -Dspark.testVersion=${{ matrix.spark }} ++${{ matrix.scala }} test scalafmtCheckAll

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,4 +17,6 @@ jobs:
       - uses: actions/checkout@v1
       - uses: olafurpg/setup-scala@v10
       - name: Test
-        run: sbt -Dspark.testVersion=${{ matrix.spark }} ++${{ matrix.scala }} test scalafmtCheckAll
+        run: sbt -Dspark.testVersion=${{ matrix.spark }} ++${{ matrix.scala }} test
+      - name: Code Quality
+        run: sbt scalafmtCheckAll

--- a/build.sbt
+++ b/build.sbt
@@ -8,11 +8,11 @@ crossScalaVersions := Seq("2.12.12")
 scalaVersion := "2.12.12"
 val sparkVersion = "3.0.1"
 
-libraryDependencies += "org.apache.spark" %% "spark-sql" % sparkVersion % "provided"
-libraryDependencies += "org.apache.spark" %% "spark-mllib" % sparkVersion % "provided"
-libraryDependencies += "com.github.mrpowers" %% "spark-fast-tests" % "1.0.0" % "test"
-libraryDependencies += "com.lihaoyi" %% "utest" % "0.6.3" % "test"
-libraryDependencies += "com.lihaoyi" %% "os-lib" % "0.7.1" % "test"
+libraryDependencies += "org.apache.spark"    %% "spark-sql"        % sparkVersion % "provided"
+libraryDependencies += "org.apache.spark"    %% "spark-mllib"      % sparkVersion % "provided"
+libraryDependencies += "com.github.mrpowers" %% "spark-fast-tests" % "1.0.0"      % "test"
+libraryDependencies += "com.lihaoyi"         %% "utest"            % "0.6.3"      % "test"
+libraryDependencies += "com.lihaoyi"         %% "os-lib"           % "0.7.1"      % "test"
 testFrameworks += new TestFramework("com.github.mrpowers.spark.daria.CustomFramework")
 
 credentials += Credentials(Path.userHome / ".sbt" / "sonatype_credentials")
@@ -35,7 +35,7 @@ publishMavenStyle := true
 
 publishTo := sonatypePublishToBundle.value
 
-Global/useGpgPinentry := true
+Global / useGpgPinentry := true
 
 // sbt-ghpages plugin: https://github.com/sbt/sbt-ghpages
 enablePlugins(SiteScaladocPlugin)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@ resolvers += Resolver.bintrayIvyRepo(
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.0")
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.4")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
-addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.3")
+addSbtPlugin("com.eed3si9n"     % "sbt-assembly" % "0.15.0")
+addSbtPlugin("org.xerial.sbt"   % "sbt-sonatype" % "3.9.4")
+addSbtPlugin("com.jsuereth"     % "sbt-pgp"      % "2.0.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages"  % "0.6.3")

--- a/src/test/scala/com/github/mrpowers/spark/daria/sql/TransformationsTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/daria/sql/TransformationsTest.scala
@@ -222,21 +222,24 @@ object TransformationsTest extends TestSuite with DataFrameComparer with ColumnC
     "snakifyColumns catch-all scenarios" - {
 
       val sourceDF = spark.createDF(
-        List(("mixed case with spaces",
-          "mixed case with spaces",
-          "multi-spaces",
-          "word with a capitalized letter",
-          "BiH",
-          "a_b_c",
-          "de_f",
-          "cr_ay",
-          "col_four",
-          "colfive",
-          "col_sevenAh",
-          "HOWABOUTTHIS",
-          "thisOne",
-          "ORACLE_CASING"
-        )),
+        List(
+          (
+            "mixed case with spaces",
+            "mixed case with spaces",
+            "multi-spaces",
+            "word with a capitalized letter",
+            "BiH",
+            "a_b_c",
+            "de_f",
+            "cr_ay",
+            "col_four",
+            "colfive",
+            "col_sevenAh",
+            "HOWABOUTTHIS",
+            "thisOne",
+            "ORACLE_CASING"
+          )
+        ),
         List(
           ("A b C", StringType, true),
           ("de F", StringType, true),
@@ -258,21 +261,24 @@ object TransformationsTest extends TestSuite with DataFrameComparer with ColumnC
       val actualDf = sourceDF.transform(transformations.toSnakeCaseColumns())
 
       val expectedDF = spark.createDF(
-        List(("mixed case with spaces",
-          "mixed case with spaces",
-          "multi-spaces",
-          "word with a capitalized letter",
-          "BiH",
-          "a_b_c",
-          "de_f",
-          "cr_ay",
-          "col_four",
-          "colfive",
-          "col_sevenAh",
-          "HOWABOUTTHIS",
-          "thisOne",
-          "ORACLE_CASING"
-        )),
+        List(
+          (
+            "mixed case with spaces",
+            "mixed case with spaces",
+            "multi-spaces",
+            "word with a capitalized letter",
+            "BiH",
+            "a_b_c",
+            "de_f",
+            "cr_ay",
+            "col_four",
+            "colfive",
+            "col_sevenAh",
+            "HOWABOUTTHIS",
+            "thisOne",
+            "ORACLE_CASING"
+          )
+        ),
         List(
           ("a_b_c", StringType, true),
           ("de_f", StringType, true),
@@ -301,21 +307,24 @@ object TransformationsTest extends TestSuite with DataFrameComparer with ColumnC
     "camelCase catch-all scenarios" - {
 
       val sourceDF = spark.createDF(
-        List(("mixed case with spaces",
-          "mixed case with spaces",
-          "multi-spaces",
-          "word with a capitalized letter",
-          "BiH",
-          "a_b_c",
-          "de_f",
-          "cr_ay",
-          "col_four",
-          "colfive",
-          "col_sevenAh",
-          "HOWABOUTTHIS",
-          "thisOne",
-          "ORACLE_CASING"
-        )),
+        List(
+          (
+            "mixed case with spaces",
+            "mixed case with spaces",
+            "multi-spaces",
+            "word with a capitalized letter",
+            "BiH",
+            "a_b_c",
+            "de_f",
+            "cr_ay",
+            "col_four",
+            "colfive",
+            "col_sevenAh",
+            "HOWABOUTTHIS",
+            "thisOne",
+            "ORACLE_CASING"
+          )
+        ),
         List(
           ("A b C", StringType, true),
           ("de F", StringType, true),
@@ -337,21 +346,24 @@ object TransformationsTest extends TestSuite with DataFrameComparer with ColumnC
       val actualDf = sourceDF.transform(transformations.camelCaseColumns())
 
       val expectedDF = spark.createDF(
-        List(("mixed case with spaces",
-          "mixed case with spaces",
-          "multi-spaces",
-          "word with a capitalized letter",
-          "BiH",
-          "a_b_c",
-          "de_f",
-          "cr_ay",
-          "col_four",
-          "colfive",
-          "col_sevenAh",
-          "HOWABOUTTHIS",
-          "thisOne",
-          "ORACLE_CASING"
-        )),
+        List(
+          (
+            "mixed case with spaces",
+            "mixed case with spaces",
+            "multi-spaces",
+            "word with a capitalized letter",
+            "BiH",
+            "a_b_c",
+            "de_f",
+            "cr_ay",
+            "col_four",
+            "colfive",
+            "col_sevenAh",
+            "HOWABOUTTHIS",
+            "thisOne",
+            "ORACLE_CASING"
+          )
+        ),
         List(
           ("aBC", StringType, true),
           ("deF", StringType, true),
@@ -380,21 +392,24 @@ object TransformationsTest extends TestSuite with DataFrameComparer with ColumnC
     "upperCase catch-all scenarios" - {
 
       val sourceDF = spark.createDF(
-        List(("mixed case with spaces",
-          "mixed case with spaces",
-          "multi-spaces",
-          "word with a capitalized letter",
-          "BiH",
-          "a_b_c",
-          "de_f",
-          "cr_ay",
-          "col_four",
-          "colfive",
-          "col_sevenAh",
-          "HOWABOUTTHIS",
-          "thisOne",
-          "ORACLE_CASING"
-        )),
+        List(
+          (
+            "mixed case with spaces",
+            "mixed case with spaces",
+            "multi-spaces",
+            "word with a capitalized letter",
+            "BiH",
+            "a_b_c",
+            "de_f",
+            "cr_ay",
+            "col_four",
+            "colfive",
+            "col_sevenAh",
+            "HOWABOUTTHIS",
+            "thisOne",
+            "ORACLE_CASING"
+          )
+        ),
         List(
           ("A b C", StringType, true),
           ("de F", StringType, true),
@@ -416,21 +431,24 @@ object TransformationsTest extends TestSuite with DataFrameComparer with ColumnC
       val actualDf = sourceDF.transform(transformations.upperCaseColumns())
 
       val expectedDF = spark.createDF(
-        List(("mixed case with spaces",
-          "mixed case with spaces",
-          "multi-spaces",
-          "word with a capitalized letter",
-          "BiH",
-          "a_b_c",
-          "de_f",
-          "cr_ay",
-          "col_four",
-          "colfive",
-          "col_sevenAh",
-          "HOWABOUTTHIS",
-          "thisOne",
-          "ORACLE_CASING"
-        )),
+        List(
+          (
+            "mixed case with spaces",
+            "mixed case with spaces",
+            "multi-spaces",
+            "word with a capitalized letter",
+            "BiH",
+            "a_b_c",
+            "de_f",
+            "cr_ay",
+            "col_four",
+            "colfive",
+            "col_sevenAh",
+            "HOWABOUTTHIS",
+            "thisOne",
+            "ORACLE_CASING"
+          )
+        ),
         List(
           ("A_B_C", StringType, true),
           ("DE_F", StringType, true),


### PR DESCRIPTION
This PR adds formatting to the CI pipeline and formats all sources based on the
included `.scalafmt.conf` configuration.
