### PR TITLE
Support scala 2.13 (to enable full spark 3.2.0 support)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,14 +4,14 @@ organization := "com.github.mrpowers"
 name := "spark-daria"
 
 version := "1.0.0"
-crossScalaVersions := Seq("2.12.12")
-scalaVersion := "2.12.12"
+crossScalaVersions := Seq("2.13.5", "2.12.12")
+scalaVersion := crossScalaVersions.value.head
 val sparkVersion = "3.0.1"
 
 libraryDependencies += "org.apache.spark"    %% "spark-sql"        % sparkVersion % "provided"
 libraryDependencies += "org.apache.spark"    %% "spark-mllib"      % sparkVersion % "provided"
 libraryDependencies += "com.github.mrpowers" %% "spark-fast-tests" % "1.0.0"      % "test"
-libraryDependencies += "com.lihaoyi"         %% "utest"            % "0.6.3"      % "test"
+libraryDependencies += "com.lihaoyi"         %% "utest"            % "0.7.9"      % "test"
 libraryDependencies += "com.lihaoyi"         %% "os-lib"           % "0.7.1"      % "test"
 testFrameworks += new TestFramework("com.github.mrpowers.spark.daria.CustomFramework")
 

--- a/src/main/scala/com/github/mrpowers/spark/daria/sql/DataFrameSchemaChecker.scala
+++ b/src/main/scala/com/github/mrpowers/spark/daria/sql/DataFrameSchemaChecker.scala
@@ -1,13 +1,42 @@
 package com.github.mrpowers.spark.daria.sql
 
 import org.apache.spark.sql.DataFrame
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{StructField, StructType}
+
+import scala.annotation.tailrec
+import scala.util.{Failure, Success, Try}
 
 case class InvalidDataFrameSchemaException(smth: String) extends Exception(smth)
 
 private[sql] class DataFrameSchemaChecker(df: DataFrame, requiredSchema: StructType) {
+  private def diff(required: Seq[StructField], schema: StructType): Seq[StructField] = {
+    required.filterNot(isPresentIn(schema))
+  }
 
-  val missingStructFields = requiredSchema.diff(df.schema)
+  private def isPresentIn(schema: StructType)(reqField: StructField): Boolean = {
+    Try(schema(reqField.name)) match {
+      case Success(namedField) =>
+        val basicMatch =
+          namedField.name == reqField.name &&
+            namedField.nullable == reqField.nullable &&
+            namedField.metadata == reqField.metadata
+
+        val contentMatch = reqField.dataType match {
+          case reqSchema: StructType =>
+            namedField.dataType match {
+              case fieldSchema: StructType =>
+                diff(reqSchema, fieldSchema).isEmpty
+              case _ => false
+            }
+          case _ => reqField == namedField
+        }
+
+        basicMatch && contentMatch
+      case Failure(_) => false
+    }
+  }
+
+  val missingStructFields: Seq[StructField] = diff(requiredSchema, df.schema)
 
   def missingStructFieldsMessage(): String = {
     s"The [${missingStructFields.mkString(", ")}] StructFields are not included in the DataFrame with the following StructFields [${df.schema.toString()}]"

--- a/src/main/scala/com/github/mrpowers/spark/daria/sql/functions.scala
+++ b/src/main/scala/com/github/mrpowers/spark/daria/sql/functions.scala
@@ -121,9 +121,9 @@ object functions {
     val d = Option(delimiters).getOrElse(return None)
     val c = Option(colName).getOrElse(return None)
     // initialize the previousLetter to be the null character - the closest representation of the empty character: https://stackoverflow.com/questions/8306060/how-do-i-represent-an-empty-char-in-scala
-    var previousLetter: Char = '\0'
+    var previousLetter: Char = '\u0000'
     Some(c.map { letter: Char =>
-      if (d.contains(previousLetter) || previousLetter.equals('\0')) {
+      if (d.contains(previousLetter) || previousLetter.equals('\u0000')) {
         previousLetter = letter
         letter.toUpper
       } else {


### PR DESCRIPTION
Issues with:
 - StructType string changes
 - Fragile schema tests because scala's .groupBy function is not deterministic in ordering, and deep schemas don't resolve
The existing tests on 2.12 should be able to be falsified just be adding a few more foo.* columns in the nested DataFrame